### PR TITLE
Replaced "planet-discovery-vulcanus" prereq in "planet-discovery-corr…

### DIFF
--- a/corrundum/data-updates.lua
+++ b/corrundum/data-updates.lua
@@ -122,7 +122,7 @@ if(update_discovery == true) then
       },
       time = 60
   }
-  data.raw["technology"]["planet-discovery-corrundum"].prerequisites = { "space-platform-thruster","planet-discovery-vulcanus"}
+  data.raw["technology"]["planet-discovery-corrundum"].prerequisites = { "space-platform-thruster","metallurgic-science-pack"}
 end
 
 local update_reduction_recipes = settings.startup["force-reduction-requires-plates"].value


### PR DESCRIPTION
…undum" tech with "metallurgic-science-pack."

This change moves the location of "planet-discovery-corrundum" to after unlocking the metallurgic science pack, to prevent the technology from becoming available before unlocking the pack.