### PR TITLE
Canal Excavator Compatibility

### DIFF
--- a/corrundum/compatibility/canal-excavator.lua
+++ b/corrundum/compatibility/canal-excavator.lua
@@ -1,0 +1,18 @@
+if not mods["canal-excavator"] then return end
+
+data:extend({{
+  type = "mod-data",
+  name = "canex-corrundum-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "corrundum",
+    localisation = {"space-location-name.corrundum"},
+    oreStartingAmount = 40,
+    mining_time = 2,
+    tint = {r = 120, g = 80, b = 60},
+    mineResult = {
+      {type="item", name = "stone", probability = 0.8, amount = 1},
+      {type="item", name = "sulfur", probability = 0.2, amount = 1},
+    }
+  }
+}})

--- a/corrundum/data.lua
+++ b/corrundum/data.lua
@@ -20,3 +20,5 @@ require("__corrundum__.prototypes.planet.corrundum-expressions")
 require("__corrundum__.prototypes.corrundum-decoratives")
 require("__corrundum__.prototypes.ambient-sounds")
 require("__corrundum__.prototypes.achievements")
+
+require("__corrundum__.compatibility.canal-excavator")

--- a/corrundum/info.json
+++ b/corrundum/info.json
@@ -6,8 +6,9 @@
     "factorio_version": "2.0",
     "dependencies": ["base >= 2.0",
         "space-age >= 2.0",
-        "? mineral-chemistry >= 1.0.0"
+        "? mineral-chemistry >= 1.0.0",
+        "? canal-excavator >= 1.12"
     ],
     "space_travel_required": true,
     "description": "○🌐This mod adds Corrundum, a planet centered around the chemistry of Sulfur."
-  }
+}


### PR DESCRIPTION
Hi it's me [again](https://github.com/ZacharyDK/Cubium/pull/16) with Canal Excavator compatibility.

For Corrundum, I've opted to yield a combination of stone and sulfur. Stone doesn't spawn natively on Corrundum except for in the rocks, so if you've got another idea for what the soil should consist of, you can change it as you wish.

Let me know what you think!