### PR TITLE
Fix ice boxes not always calculating

### DIFF
--- a/corrundum/control.lua
+++ b/corrundum/control.lua
@@ -305,7 +305,7 @@ script.on_nth_tick(53,
           --log(serpent.block(iceable_stacks))
           
           if( dry_ice_total == 0 or table_size(dry_ice_stacks) == 0 or table_size(iceable_stacks) == 0) then
-            goto end_function --No cooling power or things to cool, we done.
+            goto continue_ice_box_loop --No cooling power or things to cool, we done.
           else
              --Substract total_spoilable_stacks from dry ice durability or count, Lets go with item count
             
@@ -391,6 +391,7 @@ script.on_nth_tick(53,
               inventory.insert({ name= refreshed_item["name"],quality = refreshed_item["quality"], count =refreshed_item["count"], spoil_percent=refreshed_item["spoil_percent"] } ) 
             end 
           end
+          ::continue_ice_box_loop::
         end
 
         ::continue_surface_loop::


### PR DESCRIPTION
In some cases, ice boxes were not decrementing dry ice and keeping contents fresh if other existing ice boxes were empty. It turns out the ice box update script was sometimes skipping the remainder of uncalculated ice boxes when it encountered an ice box with no iceables. Fixed by continuing the ice box loop rather than aborting the function entirely when an empty ice box is encountered.