### PR TITLE
Support all spoilable items in ice-box

### DIFF
--- a/corrundum/control.lua
+++ b/corrundum/control.lua
@@ -1,26 +1,12 @@
-local iceable_products = {"bioflux","agricultural-science-pack","biter-egg","pentapod-egg","raw-fish"}
 local last_tick = -1 --Last time we queried ice-box
---local iceable_array_length = table.getn(iceable_products) Need to use table_size() 
 
 local lab_cache = {}
+local lab_delta_time = 45
 local ice_box_cache = {}
+local ice_box_delta_time = 53
 local initialized_cache = false
 local skip_process_lab = false --When we want to make sure we reset the cache properly
 local skip_process_ice = false
-
-local function calculate_stack_count(item_count,stack_size)
-  local out = 1
-  if(item_count <= stack_size) then
-    out = 1
-  else 
-    local complete_stacks = math.floor(item_count / stack_size) -- // is 5.3 only feature
-    out = complete_stacks
-    if(item_count % stack_size ~= 0) then --if we have any remainder, we have another incomplete stacks
-      out = complete_stacks + 1
-    end
-  end
-  return out
-end
 
 local function find_all_entity_of_name(input_name)
   local out_entity_table = {}
@@ -207,7 +193,7 @@ end
 
 
 
-script.on_nth_tick(45,
+script.on_nth_tick(lab_delta_time,
   function(NthTickEventData)
     if(skip_process_lab == true) then
       skip_process_lab = false
@@ -220,22 +206,19 @@ script.on_nth_tick(45,
   end
 )
 
-script.on_nth_tick(53,
+script.on_nth_tick(ice_box_delta_time,
   function(NthTickEventData)
-    --log("---TICK START---")
-    --log(last_tick)
     if(skip_process_ice) then
       skip_process_ice = false
       return
     end
 
     local current_tick = NthTickEventData.tick
-    local delta_time = 53
-    if(last_tick == -1 ) then --Only works if are on tick > 53. last_tick is -1 on start up
-      last_tick = NthTickEventData.tick - 53
+    if(last_tick == -1 ) then --Only works if are on tick > ice_box_delta_time. last_tick is -1 on start up
+      last_tick = NthTickEventData.tick - ice_box_delta_time
     end
 
-    if(NthTickEventData.tick < 54 or NthTickEventData.tick % 45 == 0 ) then --If we either just started or N45th tick. I already do a lot of query on the 45th tick, so I don't want to lag the game every 45*53 ticks 
+    if(NthTickEventData.tick <= ice_box_delta_time or NthTickEventData.tick % lab_delta_time == 0 ) then --If we either just started or N-lab tick. I already do a lot of query on the lab-tick, so I don't want to lag the game every lab_delta_time*ice_box_delta_time ticks
       goto end_function --fail safe
     end
 
@@ -243,9 +226,6 @@ script.on_nth_tick(53,
     for k,q in pairs(surface_array) do --names of surfaces are in keys
         local current_surface = game.get_surface(k)
         local ice_boxes = ice_box_cache[current_surface.name]
-        --log("Ice-Boxes")
-        --log(serpent.block(ice_boxes))
-
 
         if(ice_boxes == nil) then 
           goto continue_surface_loop
@@ -265,93 +245,47 @@ script.on_nth_tick(53,
           local total_spoilable_stacks = 0
           local dry_ice_stacks = {}
           for j,c in pairs(contents) do --can't cut it short if we reach ice_able_array_length, items of different quality have the same stack name
-            if(c.name == "dry-ice" ) then --can't check for values in an array -  at least efficiently. So I'll hardcode the items and stack size that I care about
-              dry_ice_stacks["dry-ice" .. c.quality] = {item_count = c.count, stack_count = calculate_stack_count(c.count,500), base_name = "dry-ice", quality_name = c.quality}
+            if(c.name == "dry-ice" ) then
+              local sc = math.ceil(c.count / 500)
+              dry_ice_stacks["dry-ice" .. c.quality] = {item_count = c.count, stack_count = sc, base_name = "dry-ice", quality_name = c.quality}
               dry_ice_total = dry_ice_total + c.count
 
-              iceable_stacks["dry-ice" .. c.quality] = {item_count = c.count, stack_count = calculate_stack_count(c.count,500), base_name = "dry-ice", quality_name = c.quality}
+              iceable_stacks["dry-ice" .. c.quality] = {item_count = c.count, stack_count = sc, base_name = "dry-ice", quality_name = c.quality}
               --Need to remember it here too to rebuild the inventory properly
               if(first_available_dry_ice_key == "") then first_available_dry_ice_key="dry-ice" .. c.quality end
-              
-            elseif (c.name == "bioflux") then
-              local sc = calculate_stack_count(c.count,100)
-              iceable_stacks["bioflux" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "bioflux", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            elseif(c.name == "agricultural-science-pack") then
-              local sc = calculate_stack_count(c.count,200)
-              iceable_stacks["agricultural-science-pack" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "agricultural-science-pack", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            elseif(c.name == "biter-egg") then
-              local sc = calculate_stack_count(c.count,100)
-              iceable_stacks["biter-egg" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "biter-egg", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            elseif(c.name == "pentapod-egg") then
-              local sc = calculate_stack_count(c.count,20)
-              iceable_stacks["pentapod-egg" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "pentapod-egg", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            elseif(c.name == "raw-fish") then
-              local sc = calculate_stack_count(c.count,100) --if this is incorrect, we will actually crash 
-              iceable_stacks["raw-fish" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "raw-fish", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-
             else
-              --local a = 1 --Do a dummy operation, not sure if else statement is required. Just having nil threw an error. I'll leave this empty for now and hope I don't need a pass statement like in Python
+                local item_prototype = prototypes.item[c.name]
+                local spoil_ticks = item_prototype.get_spoil_ticks(c.quality)
+                if spoil_ticks > 0 then
+                    local sc = math.ceil(c.count / item_prototype.stack_size)
+                    iceable_stacks[c.name .. c.quality] = {item_count = c.count, stack_count = sc,base_name = c.name, quality_name = c.quality, spoil_ticks = spoil_ticks}
+                    total_spoilable_stacks = total_spoilable_stacks + sc
+                end
             end
           end
 
-          --log("dry-ice total="..dry_ice_total)
-
-          --log("iceable_stacks:")  
-          --log(serpent.block(iceable_stacks))
-          
           if( dry_ice_total == 0 or table_size(dry_ice_stacks) == 0 or table_size(iceable_stacks) == 0) then
             goto continue_ice_box_loop --No cooling power or things to cool, we done.
-          else
-             --Substract total_spoilable_stacks from dry ice durability or count, Lets go with item count
-            
-            --local first_dry_ice_item_count = dry_ice_stacks[first_available_dry_ice_key]["item_count"]
-            --local new_dry_ice_count = first_dry_ice_item_count - total_spoilable_stacks
-            --log("first_dry_ice_item_count="..first_dry_ice_item_count)
-            --log("new_dry_ice_count="..new_dry_ice_count)
-            --log("total_spoilable_stacks="..total_spoilable_stacks)
-
-            --TODO consider goto statement if surface = aquillo
-            --if(new_dry_ice_count > 0 ) then
-              --dry_ice_stacks[first_available_dry_ice_key]["item_count"] = new_dry_ice_count
-              --iceable_stacks[first_available_dry_ice_key]["item_count"] = new_dry_ice_count --to properly rebuild the inventory
-            --else
-              --dry_ice_stacks[first_available_dry_ice_key] = nil --remove the item from this array.
-              --iceable_stacks[first_available_dry_ice_key]["item_count"] = nil 
-            --end
           end
-          --log("dry_ice_stacks")
-          --log(serpent.block(dry_ice_stacks))
+
           local rebuilt_inventory = {} 
 
           --for each item stack in the inventory
           --grab it, adjust spoilable as needed, save it, then remove it.
 
-          local handled_dry_ice_count = false  
+          local handled_dry_ice_count = false
           for h,iceable in pairs(iceable_stacks) do --We put the dry ice in here so we can remember its
             local times_to_iterate = iceable_stacks[h]["stack_count"]
-            --log("h="..h)
-            --log("iceable=")
-            --log(serpent.block(iceable))
             local iter = 0
             while (iter < times_to_iterate) do
               local item_stack = inventory.find_item_stack({name = iceable_stacks[h]["base_name"] , quality = iceable_stacks[h]["quality_name"] })
-              --log("-----")
-              --log("iter="..iter)
-              --log("item_stack")
-              --log(serpent.block(item_stack))
-              --log("-----")
-              --
-              --log("OLD_spoil_tick_time="..spoil_tick_time)
-              local count_offset = 0; --handle using dry ise for cooling power
+              local count_offset = 0; --handle using dry ice for cooling power
 
               local spoil_percent= item_stack.spoil_percent
               if(item_stack.spoil_percent >= 0.5 and iceable_stacks[h]["base_name"] ~= "dry-ice") then
-                spoil_percent = spoil_percent - 0.002 --Can't seem to get spoilage percentage with tick calculations correct. So I'll slowlly decrease the spoil percentage to 0.5
+                -- assertion: if an item spoils, spoil_ticks is never zero
+                local spoil_increase = (ice_box_delta_time / iceable_stacks[h]["spoil_ticks"]) * 1.5
+                spoil_percent = spoil_percent - spoil_increase
               end
 
               if(handled_dry_ice_count == false and iceable_stacks[h]["base_name"] == "dry-ice" and current_surface.name ~= "aquilo" ) then
@@ -363,30 +297,17 @@ script.on_nth_tick(53,
                 handled_dry_ice_count = true
               end
 
-              
               if(spoil_percent < 0) then
                 spoil_percent = 0.01
               end
 
-
               rebuilt_inventory[h..iter]= {name = item_stack.name, quality = item_stack.quality, count = item_stack.count - count_offset, spoil_percent = spoil_percent}
               inventory.remove(item_stack)
               iter = iter + 1
-              
             end
           end
           
-          --inventory.clear() --Ready to rebuild! --DOn't need to clear out everything
-          --We put dry ice in iceable so we can get the spoil percentages.
-          
-          --for m, dry_ice in pairs(dry_ice_stacks) do
-          --inventory.insert({name = dry_ice_stacks[m]["base_name"], count = dry_ice_stacks[m]["item_count"], quality = dry_ice_stacks[m]["quality_name"]})
-          --end
-          
           for r, refreshed_item in pairs(rebuilt_inventory) do
-            --log("r="..r)
-            --log("refreshed_item=")
-            --log(serpent.block(refreshed_item))
             if refreshed_item["count"] > 0 then
               inventory.insert({ name= refreshed_item["name"],quality = refreshed_item["quality"], count =refreshed_item["count"], spoil_percent=refreshed_item["spoil_percent"] } ) 
             end 
@@ -398,228 +319,7 @@ script.on_nth_tick(53,
     end
     
     last_tick = current_tick --We are done, cache the last tick
-    --log("--TICK END--")
     ::end_function::
-
-    
-
   end
 
 )
-
-
-
-
---[[
-script.on_nth_tick(45,
-  function(NthTickEventData)
-    local surface_array = game.surfaces
-    for k,q in pairs(surface_array) do --names of surfaces are in keys
-        local current_surface = game.get_surface(k)
-        local pressure_labs = current_surface.find_entities_filtered{name = "pressure-lab"}
-        --log("pressure_labs")
-        --log(serpent.block(pressure_labs))
-        for i,v in pairs(pressure_labs) do
-            --log("i="..i)
-            --log("v=")
-            --log(serpent.block(v))
-            --log("v.status=")
-            --log(serpent.block(v.status))
-            if(v.status == defines.entity_status.missing_science_packs or v.status == defines.entity_status.no_fuel or v.status == 31 or v.status ==24 ) then --Either the brackets around the defines or adding these numbers made it work. Don't like using the numbers as this could break things in the future
-              goto continue_loop -- NOT WORKING???
-     
-            end
-            local inventory = v.get_inventory(defines.inventory.lab_input)
-            local contents = inventory.get_contents()
-            for j,c in ipairs(contents) do
-                if (c.quality == "normal" ) then
-                  inventory.remove({name = c.name, count = c.count})
-                  local out_inventory = v.get_inventory(defines.inventory.lab_input)
-                  if (c.count > 1 ) then
-                    out_inventory.insert({name = c.name, count = c.count -1})
-                  end
-                end
-            end
-          ::continue_loop::
-        end
-     
-    end
-  end
-)
---]]
-
-
-
---Doesn't seem to working. But at least it doesn't crash...
--- Have to test each line, because I don't know where the error is.
---Items with less than N*2 - 1 ticks remaining will spoil. We skip the first nth tick to cache it in last tick.
-
-
-
-
-
-
---[[
-script.on_nth_tick(53,
-  function(NthTickEventData)
-    --log("---TICK START---")
-    --log(last_tick)
-    local current_tick = NthTickEventData.tick
-    local delta_time = 53
-    if(last_tick == -1 ) then --Only works if are on tick > 53. last_tick is -1 on start up
-      last_tick = NthTickEventData.tick - 53
-    end
-
-    if(NthTickEventData.tick < 54 or NthTickEventData.tick % 45 == 0) then --If we either just started or N45th tick. I already do a lot of query on the 45th tick, so I don't want to lag the game every 45*53 ticks 
-      goto end_function --fail safe
-    end
-    --local delta_time = current_tick - last_tick --Did I mess this up?
-    
-    
-    --log("delta_time="..delta_time)
-    local surface_array = game.surfaces
-    for k,q in pairs(surface_array) do --names of surfaces are in keys
-        local current_surface = game.get_surface(k)
-        local ice_boxes = current_surface.find_entities_filtered{name = "ice-box"}
-        --log("Ice-Boxes")
-        --log(serpent.block(ice_boxes))
-        for i,v in pairs(ice_boxes) do
-          local inventory = v.get_inventory(defines.inventory.chest)
-          local iceable_stacks = {}
-          local contents = inventory.get_contents() --We have to dump the contents of the array to figure out how many item stacks we have to query
-          local dry_ice_total = 0
-          local first_available_dry_ice_key = "" --no longer necessary but I'll leave it in case I want to expand on it.
-          local total_spoilable_stacks = 0
-          local dry_ice_stacks = {}
-          for j,c in pairs(contents) do --can't cut it short if we reach ice_able_array_length, items of different quality have the same stack name
-            if(c.name == "dry-ice" ) then --can't check for values in an array -  at least efficiently. So I'll hardcode the items and stack size that I care about
-              dry_ice_stacks["dry-ice" .. c.quality] = {item_count = c.count, stack_count = calculate_stack_count(c.count,500), base_name = "dry-ice", quality_name = c.quality}
-              dry_ice_total = dry_ice_total + c.count
-
-              iceable_stacks["dry-ice" .. c.quality] = {item_count = c.count, stack_count = calculate_stack_count(c.count,500), base_name = "dry-ice", quality_name = c.quality}
-              --Need to remember it here too to rebuild the inventory properly
-              if(first_available_dry_ice_key == "") then first_available_dry_ice_key="dry-ice" .. c.quality end
-              
-            elseif (c.name == "bioflux") then
-              local sc = calculate_stack_count(c.count,100)
-              iceable_stacks["bioflux" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "bioflux", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            elseif(c.name == "agricultural-science-pack") then
-              local sc = calculate_stack_count(c.count,200)
-              iceable_stacks["agricultural-science-pack" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "agricultural-science-pack", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            elseif(c.name == "biter-egg") then
-              local sc = calculate_stack_count(c.count,100)
-              iceable_stacks["biter-egg" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "biter-egg", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            elseif(c.name == "pentapod-egg") then
-              local sc = calculate_stack_count(c.count,20)
-              iceable_stacks["pentapod-egg" .. c.quality] = {item_count = c.count, stack_count = sc,base_name = "pentapod-egg", quality_name = c.quality}
-              total_spoilable_stacks = total_spoilable_stacks + sc
-            else
-              --local a = 1 --Do a dummy operation, not sure if else statement is required. Just having nil threw an error. I'll leave this empty for now and hope I don't need a pass statement like in Python
-            end
-          end
-
-          --log("dry-ice total="..dry_ice_total)
-
-          --log("iceable_stacks:")  
-          --log(serpent.block(iceable_stacks))
-          
-          if( dry_ice_total == 0 or table_size(dry_ice_stacks) == 0 or table_size(iceable_stacks) == 0 and current_surface.name ~= "aquilo") then
-            goto end_function --No cooling power or things to cool, we done.
-          else
-             --Substract total_spoilable_stacks from dry ice durability or count, Lets go with item count
-            
-            --local first_dry_ice_item_count = dry_ice_stacks[first_available_dry_ice_key]["item_count"]
-            --local new_dry_ice_count = first_dry_ice_item_count - total_spoilable_stacks
-            --log("first_dry_ice_item_count="..first_dry_ice_item_count)
-            --log("new_dry_ice_count="..new_dry_ice_count)
-            --log("total_spoilable_stacks="..total_spoilable_stacks)
-
-            --TODO consider goto statement if surface = aquillo
-            --if(new_dry_ice_count > 0 ) then
-              --dry_ice_stacks[first_available_dry_ice_key]["item_count"] = new_dry_ice_count
-              --iceable_stacks[first_available_dry_ice_key]["item_count"] = new_dry_ice_count --to properly rebuild the inventory
-            --else
-              --dry_ice_stacks[first_available_dry_ice_key] = nil --remove the item from this array.
-              --iceable_stacks[first_available_dry_ice_key]["item_count"] = nil 
-            --end
-          end
-          --log("dry_ice_stacks")
-          --log(serpent.block(dry_ice_stacks))
-          local rebuilt_inventory = {} 
-
-          --for each item stack in the inventory
-          --grab it, adjust spoilable as needed, save it, then remove it.
-
-          local handled_dry_ice_count = false  
-          for h,iceable in pairs(iceable_stacks) do --We put the dry ice in here so we can remember its
-            local times_to_iterate = iceable_stacks[h]["stack_count"]
-            --log("h="..h)
-            --log("iceable=")
-            --log(serpent.block(iceable))
-            local iter = 0
-            while (iter < times_to_iterate) do
-              local item_stack = inventory.find_item_stack({name = iceable_stacks[h]["base_name"] , quality = iceable_stacks[h]["quality_name"] })
-              --log("-----")
-              --log("iter="..iter)
-              --log("item_stack")
-              --log(serpent.block(item_stack))
-              --log("-----")
-              --
-              --log("OLD_spoil_tick_time="..spoil_tick_time)
-              local count_offset = 0; --handle using dry ise for cooling power
-
-              local spoil_percent= item_stack.spoil_percent
-              if(item_stack.spoil_percent >= 0.5 and iceable_stacks[h]["base_name"] ~= "dry-ice") then
-                spoil_percent = spoil_percent - 0.002 --Can't seem to get spoilage percentage with tick calculations correct. So I'll slowlly decrease the spoil percentage to 0.5
-              end
-
-              if(handled_dry_ice_count == false and iceable_stacks[h]["base_name"] == "dry-ice" and current_surface.name ~= "aquilo" ) then
-                count_offset = math.floor(total_spoilable_stacks/4) + 1
-                handled_dry_ice_count = true
-              end
-
-              
-              if(spoil_percent < 0) then
-                spoil_percent = 0.01
-              end
-
-
-              rebuilt_inventory[h..iter]= {name = item_stack.name, quality = item_stack.quality, count = item_stack.count - count_offset, spoil_percent = spoil_percent}
-              inventory.remove(item_stack)
-              iter = iter + 1
-              
-            end
-          end
-          
-          --inventory.clear() --Ready to rebuild! --DOn't need to clear out everything
-          --We put dry ice in iceable so we can get the spoil percentages.
-          
-          --for m, dry_ice in pairs(dry_ice_stacks) do
-          --inventory.insert({name = dry_ice_stacks[m]["base_name"], count = dry_ice_stacks[m]["item_count"], quality = dry_ice_stacks[m]["quality_name"]})
-          --end
-          
-          for r, refreshed_item in pairs(rebuilt_inventory) do
-            --log("r="..r)
-            --log("refreshed_item=")
-            --log(serpent.block(refreshed_item))
-            if refreshed_item["count"] > 0 then
-              inventory.insert({ name= refreshed_item["name"],quality = refreshed_item["quality"], count =refreshed_item["count"], spoil_percent=refreshed_item["spoil_percent"] } ) 
-            end 
-          end
-        end
-    end
-    
-    last_tick = current_tick --We are done, cache the last tick
-    --log("--TICK END--")
-    ::end_function::
-
-    
-
-  end
-
-
-)
---]]


### PR DESCRIPTION
Resolves the issue I noted in #18.

Instead of a hardcoded list of spoilable items we check the item dictionary if an item is spoilable and calculate the refresh double according to its spoil_ticks. This way we can even refresh items with a low shelf life, like bacteria or jelly.

This also cleans up the code a bit - drops some variables that are unused, adds some variables for constants and removes commented out code which is unnecessary in a VCS project.