### PR TITLE
Filter events to improve performance

### DIFF
--- a/corrundum/control.lua
+++ b/corrundum/control.lua
@@ -173,8 +173,8 @@ for _, eventType in pairs({
         add_to_cache(entity,ice_box_cache)
       end
 
-		end)
-		--{{ filter = "name", name ="pressure-lab"}})
+		end,
+		{{filter = "name", name = "pressure-lab"}, {filter = "name", name = "ice-box"}})
 end
 
 for _, eventType in pairs({
@@ -199,8 +199,8 @@ for _, eventType in pairs({
       --lab_cache = nil
       --lab_cache = find_all_entity_of_name("pressure-lab")
       --lab_cache = find_all_entity_of_name("pressure-lab")
-		end)
-		--{{ filter = "name", name = "pressure-lab" }})
+		end,
+		{{filter = "name", name = "pressure-lab"}, {filter = "name", name = "ice-box"}})
 end
 
 


### PR DESCRIPTION
This change filters the event handlers to only receive the two entities it cares about. Results in a massive reduction in update time on my factory running prometheum science (from 200+ microseconds down to almost nothing), as the script otherwise wastes a lot of time receiving on_entity_died events for thousands of asteroids every second.